### PR TITLE
Dev

### DIFF
--- a/examples/KLambda/ProcessMCMatchedKLambda.C
+++ b/examples/KLambda/ProcessMCMatchedKLambda.C
@@ -1,0 +1,259 @@
+#include "ePICReaction.h"
+#include "ParticleCreator.h"
+#include "ePICParticleCreator.h"
+#include "ParticleModifier.h"
+#include "ePICParticleModifier.h"
+#include "Indicing.h"
+#include "Histogrammer.h"
+#include "BasicKinematicsRDF.h"
+#include "ReactionKinematicsRDF.h"
+#include "ElectronScatterKinematicsRDF.h"
+#include "gammaN_2_Spin0Spin0SpinHalfRDF.h"
+#include <TBenchmark.h>
+#include <TCanvas.h>
+#include <TMath.h>
+
+// Run shell command and capture output
+std::vector<std::string> runCommand(const std::string& cmd) {
+    std::vector<std::string> lines;
+    FILE* pipe = gSystem->OpenPipe(cmd.c_str(), "r");
+    if (!pipe) {
+        std::cerr << "Error: cannot run command " << cmd << std::endl;
+        return lines;
+    }
+    char buffer[1024];
+    while (fgets(buffer, sizeof(buffer), pipe) != nullptr) {
+        std::string line(buffer);
+        line.erase(line.find_last_not_of(" \n\r\t") + 1); // trim whitespace
+        if (!line.empty()) lines.push_back(line);
+    }
+    gSystem->ClosePipe(pipe);
+    return lines;
+}
+
+// Return list of ROOT files from XRootD directory
+std::vector<std::string> GetXRootDFiles(const char* redirector,
+                                        const char* xrdfsPath,
+					const char* extension = "edm4eic.root",
+					int maxFiles = -1) {
+    std::ostringstream cmd;
+    cmd << "xrdfs " << redirector << " ls " << xrdfsPath;
+    auto files = runCommand(cmd.str());
+    
+     // Sort to make sure 0001, 0002, ... order
+    std::sort(files.begin(), files.end());
+    
+    std::vector<std::string> filelist;
+    for (auto& f : files) {
+        if (TString(f).EndsWith(extension)) {
+            filelist.push_back("root://" + std::string(redirector) + f);
+	     if (maxFiles > 0 && (int)filelist.size() >= maxFiles) break;
+	}
+    }
+    
+    if (filelist.empty()) {
+        std::cerr << "Warning: No " << extension
+                  << " files found under " << xrdfsPath << std::endl;
+    }
+
+    return filelist;
+}
+void ProcessMCMatchedKLambda(std::string infile="/w/work0/home/rachel/TDISEIC/data/reco/k_lambda_18x275_5000evt_001.edm4eic.root", const std::string outfile="/w/work5/home/garyp/rad_trees/MCMatched_KLambda_18x275.root"){
+  using namespace rad::names::data_type; //for Rec(), Truth()
+  ROOT::EnableImplicitMT(8);
+  
+  gBenchmark->Start("df total");
+  infile="root://dtn-eic.jlab.org//volatile/eic/romanov/meson-structure-2025-08/reco/18x275/k_lambda_18x275_5000evt_2000.edm4eic.root";
+  auto files = GetXRootDFiles("dtn-eic.jlab.org/","/volatile/eic/romanov/meson-structure-2025-08/reco/18x275/","edm4eic.root",-1);
+  for(auto file : files)
+    std::cout << file << std::endl;
+  rad::config::ePICReaction epic{"events",files};
+  epic.SetBeamsFromMC(); //for this file 0=ebeam 1=pbeam
+  
+  epic.AliasColumnsAndMatchWithMC();
+  
+  //rad::indice::UseAsID(index, offset) offset in case beam particle included in record
+  epic.setScatElectron(rad::indice::UseAsID(0,2), {"MCScatteredElectrons_objIdx.index"});
+  //epic.setParticleIndex("pprime",rad::indice::UseAsID(0,2),{"MCScatteredProtons_objIdx.index"},2212);
+
+  
+  //particle creator
+  rad::epic::ePICParticleCreator epic_particles{epic};
+  rad::epic::ePICParticleModifier  epic_modifier(epic);
+  
+  //Lambda^0_s
+  epic.setParticleIndex("Lambda",2,3122);
+  epic_particles.MCMatchedZDCLambda("Lambda");
+  //K^+ tagged meson - becomes inclusive missing X
+  epic.setParticleIndex("K",1,321);
+  
+  epic.Particles().Miss("missX",{rad::names::ScatEle().data(),"Lambda"});
+  
+  epic.setMesonParticles({"missX"});
+  epic.setBaryonParticles({"Lambda"});
+ 
+  //must call this after all particles are configured
+  epic.makeParticleMap();
+  
+  epic_modifier.UndoCrossAngle("Lambda");
+  epic_modifier.Apply("LambdaCrossAngle");
+  
+  //option filtering of reconstructed tracks
+  //epic.Filter("el_OK==1&&po_OK==1","partFilter");
+  //epic.Filter("rec_pmag[scat_ele]>0.1","pmag_scat_ele_filt");
+  //epic.Filter("rec_pmag[Lambda]>0.1","pmag_Lambda_filt");
+  
+  //////////////////////////////////////////////////////////
+  // Now define calculated variables
+  // Note reconstructed variables will have rec_ prepended
+  // truth variables will have tru_ prepended
+  //////////////////////////////////////////////////////////
+
+  //masses column name, {+ve particles}, {-ve particles}
+  rad::rdf::MissMass(epic,"Welec","{scat_ele}");
+  rad::rdf::Mass(epic,"Whad","{missX,Lambda}");
+  rad::rdf::Q2(epic,"Q2");
+
+  //t distribution, column name
+  rad::rdf::TTop(epic,"t_top");
+  rad::rdf::TBot(epic,"t_bot");
+  rad::rdf::TPrimeTop(epic,"tp_top");
+  rad::rdf::TPrimeBot(epic,"tp_bot");
+  
+  //CM production angles
+  rad::rdf::CMAngles(epic,"CM");
+
+  //exlusivity
+  rad::rdf::MissMass(epic,"MissMassX","{scat_ele,Lambda}");
+  rad::rdf::MissP(epic,"MissP_X","{scat_ele,K}");
+  rad::rdf::MissPt(epic,"MissPt_X","{scat_ele,K}");
+  rad::rdf::MissPz(epic,"MissPz_X","{scat_ele,K}");
+  rad::rdf::MissTheta(epic,"MissTheta_X","{scat_ele,K}");
+
+  //decay angles
+  rad::rdf::gn2s0s0s12::HelicityAngles(epic,"Heli");
+
+  ///////////////////////////////////////////////////////////
+  //Define histograms
+  ///////////////////////////////////////////////////////////
+  rad::histo::Histogrammer histo{"set1",epic};
+  // we can create many histograms by splitting events into
+  // bins, where the same histogram is produced for the given bin
+  // e.g. create 10 bins in tru_W between 4 and 54 GeV 
+  //histo.Splitter().AddRegularDimension(Truth()+"W", rad::histo::RegularSplits(10,4,14) );
+  //can add as many split dimensions as we like
+  //histo.Splitter().AddRegularDimension("xxx", rad::histo::RegularSplits(nbins,low,high) );
+  histo.Init({Rec(),Truth()});//will create histograms for rec and truth
+
+  histo.Create<TH1D,double>({"hQ2",";Q^{2} [GeV^{2}]",100,0,500.},{"Q2"});
+  histo.Create<TH1D,double>({"hWelec",";W (electro miss mass) [GeV/c^{2}]",100,0,200.},{"Welec"});
+  histo.Create<TH1D,double>({"hWhad",";W (hadro final state) [GeV/c^{2}]",100,0,200.},{"Whad"});
+  histo.Create<TH1D,double>({"hMissMassX",";M_{miss} [GeV/c^{2}]",1000,-200,200},{"MissMassX"});
+  
+  histo.Create<TH1D,double>({"httop",";t(top vertex) [GeV^{2}]",100,-1,5},{"t_top"});
+  histo.Create<TH1D,double>({"htbot",";t(bottom vertex) [GeV^{2}]",100,-1,5},{"t_bot"});
+  histo.Create<TH1D,double>({"htptop",";t'(top vertex) [GeV^{2}]",100,-1,5},{"tp_top"});
+  histo.Create<TH1D,double>({"htpbot",";t'(bottom vertex) [GeV^{2}]",100,-1,5},{"tp_bot"});
+  
+  histo.Create<TH1D,double>({"hcthCM",";cos(#theta_{CM})",100,-1,1},{"CM_CosTheta"});
+  histo.Create<TH1D,double>({"hphCM",";#phi_{CM}",100,-TMath::Pi(),TMath::Pi()},{"CM_Phi"});
+  
+  histo.Create<TH1D,double>({"hmissP",";p_{miss}(e',K)",1000,-100,100},{"MissP_X"});
+  histo.Create<TH1D,double>({"hmissPt",";p_{t,miss}(e',K)",100,0,10},{"MissPt_X"});
+  histo.Create<TH1D,double>({"hmissPz",";p_{z,miss}(e',K)",1000,-100,100},{"MissPz_X"});
+  histo.Create<TH1D,double>({"hmissTheta",";#theta_{miss}(e',K)",100,-TMath::Pi(),TMath::Pi()},{"MissTheta_X"});
+ 
+  //particle momenta
+  histo.Create<TH1D,double>({"hpmag_elec",";p_{e'} [GeV/c]",100,-1,20},{"pmag[scat_ele]"});
+  histo.Create<TH1D,double>({"heta_elec",";#eta_{e'} ",100,-10,10},{"eta[scat_ele]"});
+  histo.Create<TH1D,double>({"htheta_elec",";#theta_{e'} [rad]",100,-TMath::Pi(),TMath::Pi()},{"theta[scat_ele]"});
+  histo.Create<TH1D,double>({"hphi_elec",";#phi_{e'} [rad]",100,-TMath::Pi(),TMath::Pi()},{"phi[scat_ele]"});
+  
+  histo.Create<TH1D,double>({"hpmag_Lambda",";p_{p'} [GeV/c]",100,-1,300},{"pmag[Lambda]"});
+  histo.Create<TH1D,double>({"heta_Lambda",";#eta_{p'} ",100,-10,10},{"eta[Lambda]"});
+  histo.Create<TH1D,double>({"htheta_Lambda",";#theta_{p'} [rad]",1000,0,1},{"theta[Lambda]"});
+  histo.Create<TH1D,double>({"hphi_Lambda",";#phi_{p'} [rad]",100,-TMath::Pi(),TMath::Pi()},{"phi[Lambda]"});
+  
+  //finally, book lazy snapshot before processing
+  //benchmark here will be zero if lazy snapshot
+  //which now works and will be booked till trigger
+  gBenchmark->Start("snapshot");
+  epic.BookLazySnapshot(outfile);
+  //epic.Snapshot("MCMatchedKLambda.root");
+  gBenchmark->Stop("snapshot");
+  gBenchmark->Print("snapshot");
+
+  gBenchmark->Start("processing");
+  ///////////////////////////////////////////////////////////
+  //Draw histograms
+  ///////////////////////////////////////////////////////////
+  
+  
+  TCanvas *c00 = new TCanvas();
+  c00->Divide(2,2);
+  c00->cd(1)->SetLogy();
+  histo.DrawSame("hQ2",gPad);
+  c00->cd(2)->SetLogy();
+  histo.DrawSame("hWelec",gPad);
+  c00->cd(3)->SetLogy();
+  histo.DrawSame("hWhad",gPad);
+  c00->cd(4)->SetLogy();
+  histo.DrawSame("hMissMassX",gPad);
+
+  TCanvas *c01 = new TCanvas();
+  c01->Divide(2,2);
+  c01->cd(1)->SetLogy();
+  histo.DrawSame("httop",gPad);
+  c01->cd(2)->SetLogy();
+  histo.DrawSame("htbot",gPad);
+  c01->cd(3)->SetLogy();
+  histo.DrawSame("htptop",gPad);
+  c01->cd(4)->SetLogy();
+  histo.DrawSame("htpbot",gPad);
+  
+  TCanvas *c02 = new TCanvas();
+  c02->Divide(2,2);
+  c02->cd(1)->SetLogy();
+  histo.DrawSame("hmissP",gPad);
+  c02->cd(2)->SetLogy();
+  histo.DrawSame("hmissPt",gPad);
+  c02->cd(3)->SetLogy();
+  histo.DrawSame("hmissPz",gPad);
+  c02->cd(4)->SetLogy();
+  histo.DrawSame("hmissTheta",gPad);
+  
+  //reco elec kin
+  TCanvas *c03 = new TCanvas();
+  c03->Divide(2,2);
+  c03->cd(1)->SetLogy();
+  histo.DrawSame("hpmag_elec",gPad);
+  c03->cd(2)->SetLogy();
+  histo.DrawSame("heta_elec",gPad);
+  c03->cd(3)->SetLogy();
+  histo.DrawSame("htheta_elec",gPad);
+  c03->cd(4)->SetLogy();
+  histo.DrawSame("hphi_elec",gPad);
+  
+  //reco proton kin
+  TCanvas *c04 = new TCanvas();
+  c04->Divide(2,2);
+  c04->cd(1)->SetLogy();
+  histo.DrawSame("hpmag_Lambda",gPad);
+  c04->cd(2)->SetLogy();
+  histo.DrawSame("heta_Lambda",gPad);
+  c04->cd(3)->SetLogy();
+  histo.DrawSame("htheta_Lambda",gPad);
+  c04->cd(4)->SetLogy();
+  histo.DrawSame("hphi_Lambda",gPad);
+  
+  gBenchmark->Stop("processing");
+  gBenchmark->Print("processing");
+
+  //save all histograms to file
+  //histo.File("MCMatchedKLambda_hists.root");
+
+  gBenchmark->Stop("df total");
+  gBenchmark->Print("df total");
+  
+  
+}

--- a/include/ePICParticleCreator.h
+++ b/include/ePICParticleCreator.h
@@ -41,7 +41,7 @@ namespace rad{
 	py.push_back(0.);
 	pz.push_back(0.);
 	m.push_back(0.);
-	pdg.push_back(0.);
+	pdg.push_back(rad::constant::InvalidEntry<int>());
 	/* px[idx] = (0.); */
  	/* py[idx] = (0.); */
 	/* pz[idx] = (0.); */
@@ -95,34 +95,26 @@ namespace rad{
 	DetectorParticle(rad::names::ScatEle(), "TaggerTrackerTracks","tagger",rad::constant::M_ele());
       }
       
-      void RomanPotProton(const std::string name="pprime") {
+      void RomanPotProton(const std::string name="RPproton") {
 	DetectorParticle(name, "ForwardRomanPotRecParticles","rp",rad::constant::M_pro());
       }
       
-      void B0Proton(const std::string name="pprime"){
-	//DetectorParticle(name, "ReconstructedTruthSeededChargedParticles","B0",rad::constant::M_pro());
-	
-	Reaction()->setBranchAlias("ReconstructedTruthSeededChargedParticles.momentum.x","B0_px");
-	Reaction()->setBranchAlias("ReconstructedTruthSeededChargedParticles.momentum.y","B0_py");
-	Reaction()->setBranchAlias("ReconstructedTruthSeededChargedParticles.momentum.z","B0_pz");
-	Reaction()->setBranchAlias("ReconstructedTruthSeededChargedParticles.mass","B0_m");
-	Reaction()->setBranchAlias("ReconstructedTruthSeededChargedParticles.PDG","B0_pdg");
-	
-	/* Reaction()->Define(Rec()+"B0proton",Form("rad::epic::Particle(B0_px,B0_py,B0_pz,0.93827208943,%spx,%spy,%spz,%sm,{0})",Rec().data(),Rec().data(),Rec().data(),Rec().data())); */
-	/* Reaction()->AddParticleName(Rec()+"B0proton"); */
-	/* Reaction()->Define(Rec()+"B0Proton",Form("if(rec_%s==-1) return rad::epic::Particle(%s,B0_px,B0_py,B0_pz,B0_m,B0_pdg,%spx,%spy,%spz,%sm,%spid,{0})",name.data(),name.data(),Rec().data(),Rec().data(),Rec().data(),Rec().data(),Rec().data())); */
-	/* Reaction()->AddParticleName(Rec()+"B0Proton"); */
-	
-      }
+      void B0Proton(const std::string name="B0proton"){
+	DetectorParticle(name, "ReconstructedTruthSeededChargedParticles","B0",rad::constant::M_pro());
+        }
       
-      void FarForwardProton(const std::string name="pprime"){
-	RomanPotProton(name);
-	B0Proton(name);
-	/* Reaction()->Define(Rec()+"B0proton",Form("rad::epic::Particle(B0_px,B0_py,B0_pz,0.93827208943,%spx,%spy,%spz,%sm,{0})",Rec().data(),Rec().data(),Rec().data(),Rec().data())); */
-	/* Reaction()->AddParticleName(Rec()+"B0proton"); */
-      }
+      //dont use this like this
+      //cleaner to get seperate RP and B0 particles out of the detectors
+      //then choose what to do with them after particle map
+      //i.e. Overwrite(pprime,RPproton) etc.
+      /* void FarForwardProton(const std::string name="pprime"){ */
+      /* 	RomanPotProton(name); */
+      /* 	B0Proton(name); */
+      /* 	/\* Reaction()->Define(Rec()+"B0proton",Form("rad::epic::Particle(B0_px,B0_py,B0_pz,0.93827208943,%spx,%spy,%spz,%sm,{0})",Rec().data(),Rec().data(),Rec().data(),Rec().data())); *\/ */
+      /* 	/\* Reaction()->AddParticleName(Rec()+"B0proton"); *\/ */
+      /* } */
       
-      void ZDCLambda(const std::string name="lambda"){
+      void ZDCLambda(const std::string name="ZDClambda"){
 	DetectorParticle(name,"ReconstructedFarForwardZDCLambdas","ZDC",rad::constant::M_Lambda());
       }
       
@@ -182,7 +174,6 @@ namespace rad{
 	Reaction()->setBranchAlias("ReconstructedTruthSeededChargedParticles.momentum.y","B0_py");
 	Reaction()->setBranchAlias("ReconstructedTruthSeededChargedParticles.momentum.z","B0_pz");
 	Reaction()->setBranchAlias("ReconstructedTruthSeededChargedParticles.mass","B0_m");
-	
 	//to do - make this work with the new MCMatchedParticle intermediate function style above
 	//if RP exists use that
 	//if not consider B0 candidates

--- a/include/ePICParticleCreator.h
+++ b/include/ePICParticleCreator.h
@@ -137,7 +137,68 @@ namespace rad{
 	Reaction()->Define(Rec()+"B0proton",Form("rad::epic::ParticleMCMatched(10,%s,B0_px,B0_py,B0_pz,0.93827208943,%spx,%spy,%spz,%sm,%s)",name.data(),Rec().data(),Rec().data(),Rec().data(),Rec().data(),(Truth()+"match_id").data()));
 	Reaction()->AddParticleName(Rec()+"B0proton");
       }
-     
+      
+      void ZDCLambda(const std::string name="lambda"){
+	Reaction()->setBranchAlias("ReconstructedFarForwardZDCLambdas.momentum.x","ZDC_px");
+	Reaction()->setBranchAlias("ReconstructedFarForwardZDCLambdas.momentum.y","ZDC_py");
+	Reaction()->setBranchAlias("ReconstructedFarForwardZDCLambdas.momentum.z","ZDC_pz");
+	Reaction()->setBranchAlias("ReconstructedFarForwardZDCLambdas.momentum.x","ZDC_px");
+	Reaction()->setBranchAlias("ReconstructedFarForwardZDCLambdas.momentum.y","ZDC_py");
+	Reaction()->setBranchAlias("ReconstructedFarForwardZDCLambdas.PDG","ZDC_pdg");
+	
+	Reaction()->Define(Rec()+"ZDClambda",Form("rad::epic::Particle(ZDC_px,ZDC_py,ZDC_pz,1.1115683,%spx,%spy,%spz,%sm,{0})",Rec().data(),Rec().data(),Rec().data(),Rec().data()));
+	Reaction()->AddParticleName(Rec()+"ZDClambda");
+
+      }
+      
+      //to do - swap above functions to call this one
+      //and check for bugs
+      void DetectorParticle(const std::string name, const std::string branchname, const std::string aliasname, const double mass){
+	std::string smass = to_string(mass);
+	
+	Reaction()->setBranchAlias(branchname+".momentum.x",aliasname+"_px");
+	Reaction()->setBranchAlias(branchname+".momentum.y",aliasname+"_py");
+	Reaction()->setBranchAlias(branchname+".momentum.z",aliasname+"_pz");
+	
+	Reaction()->Define(Rec()+aliasname,Form("rad::epic::Particle(%s_px,%s_py,%s_pz,%s,%spx,%spy,%spz,%sm,{0}",aliasname.data(),aliasname.data(),aliasname.data(),smass.data(),Rec().data(),Rec().data(),Rec().data(),Rec().data()));
+	Reaction()->AddParticleName(Rec()+aliasname);
+	
+      }
+
+
+      /////////////////////
+      //MC Matched Functions
+      void MCMatchedParticle(const std::string name, const std::string matchname, const std::string branchname, const std::string aliasname, const double mass, const double thresh){
+	
+	std::string smass = to_string(mass);
+	std::string sthresh = to_string(thresh);
+	
+	Reaction()->setBranchAlias(branchname+".momentum.x",aliasname+"_px");
+	Reaction()->setBranchAlias(branchname+".momentum.y",aliasname+"_py");
+	Reaction()->setBranchAlias(branchname+".momentum.z",aliasname+"_pz");
+	
+	//to do - string utility to replace form
+	//make function
+	Reaction()->Define(Rec()+name,Form("rad::epic::ParticleMCMatched(%s,%s,%s_px,%s_py,%s_pz,%s,%spx,%spy,%spz,%sm,%s)",sthresh.data(),matchname.data(),aliasname.data(),aliasname.data(),aliasname.data(),smass.data(),Rec().data(),Rec().data(),Rec().data(),Rec().data(),(Truth()+"match_id").data()));
+	Reaction()->AddParticleName(Rec()+name);
+      }
+      
+      void MCMatchedLowQ2Electron() {
+	MCMatchedParticle(rad::names::ScatEle(), rad::names::ScatEle(), "TaggerTrackerTracks", "tagger", rad::constant::M_ele(), 0.1);
+      }
+      
+      void MCMatchedRomanPotProton(const std::string matchname="pprime") {
+	MCMatchedParticle("RPproton", matchname, "ForwardRomanPotRecParticles", "rp", rad::constant::M_pro(), 10);
+      }
+      
+      void MCMatchedB0Proton(const std::string matchname="pprime") {
+	MCMatchedParticle("B0proton", matchname, "ReconstructedTruthSeededChargedParticles", "B0", rad::constant::M_pro(), 10);
+      }
+      
+      void MCMatchedZDCLambda(const std::string matchname="lambda"){
+	MCMatchedParticle("ZDClambda", matchname, "ReconstructedFarForwardZDCLambdas", "ZDC", rad::constant::M_Lambda(), 10);
+      }
+      
       void MCMatchedFarForwardProton(const std::string name="pprime") {
 	MCMatchedRomanPotProton(name);
 	Reaction()->setBranchAlias("ReconstructedTruthSeededChargedParticles.momentum.x","B0_px");

--- a/include/ePICParticleCreator.h
+++ b/include/ePICParticleCreator.h
@@ -24,28 +24,29 @@ namespace rad{
       auto idx = px.size();
       if(tpx.empty()==false){
 	//add new components
-	/* px.push_back(tpx[entry]); */
-	/* py.push_back(tpy[entry]); */
-	/* pz.push_back(tpz[entry]); */
-	/* m.push_back(tmass[entry]); */
-	/* pdg.push_back(tpdg[entry]); */
-	px = (tpx[entry]);
-	py = (tpy[entry]);
-	pz = (tpz[entry]);
-	m = (tmass[entry]);
-	pdg = (tpdg[entry]);
+	px.push_back(tpx[entry]);
+	py.push_back(tpy[entry]);
+	pz.push_back(tpz[entry]);
+	m.push_back(tmass[entry]);
+	pdg.push_back(tpdg[entry]);
+	/* px[idx] = (tpx[entry]); */
+	/* py[idx] = (tpy[entry]); */
+	/* pz[idx] = (tpz[entry]); */
+	/* m[idx] = (tmass[entry]); */
+	/* pdg[idx] = (tpdg[entry]); */
 	
       }
       else{
-	/* px.push_back(0.); */
-	/* py.push_back(0.); */
-	/* pz.push_back(0.); */
-	/* m.push_back(0.); */
-	px = (0.);
-	py = (0.);
-	pz = (0.);
-	m = (0.);
-	pdg = (0.);
+	px.push_back(0.);
+	py.push_back(0.);
+	pz.push_back(0.);
+	m.push_back(0.);
+	pdg.push_back(0.);
+	/* px[idx] = (0.); */
+ 	/* py[idx] = (0.); */
+	/* pz[idx] = (0.); */
+	/* m[idx] = (0.); */
+	/* pdg[idx] = (0.); */
 	
       }
       return idx;
@@ -91,36 +92,34 @@ namespace rad{
       
       //Detector functions (not mc matched)
       void LowQ2Electron() {
-	Reaction()->setBranchAlias("TaggerTrackerTracks.momentum.x","tagger_px");
-	Reaction()->setBranchAlias("TaggerTrackerTracks.momentum.y","tagger_py");
-	Reaction()->setBranchAlias("TaggerTrackerTracks.momentum.z","tagger_pz");
-	
-	Reaction()->Define(Rec()+rad::names::ScatEle(),Form("rad::epic::Particle(tagger_px,tagger_py,tagger_pz,0.00051099900,%spx,%spy,%spz,%sm,{0})",Rec().data(),Rec().data(),Rec().data(),Rec().data()));
-	Reaction()->AddParticleName(Rec()+rad::names::ScatEle());
-
+	DetectorParticle(rad::names::ScatEle(), "TaggerTrackerTracks","tagger",rad::constant::M_ele());
       }
       
       void RomanPotProton(const std::string name="pprime") {
-	Reaction()->setBranchAlias("ForwardRomanPotRecParticles.momentum.x","rp_px");
-	Reaction()->setBranchAlias("ForwardRomanPotRecParticles.momentum.y","rp_py");
-	Reaction()->setBranchAlias("ForwardRomanPotRecParticles.momentum.z","rp_pz");
-	
-	Reaction()->Define(Rec()+name,Form("rad::epic::Particle(rp_px,rp_py,rp_pz,0.93827208943,%spx,%spy,%spz,%sm,%s)",Rec().data(),Rec().data(),Rec().data(),Rec().data(),(Truth()+"match_id").data()));
-	Reaction()->AddParticleName(Rec()+name);
+	DetectorParticle(name, "ForwardRomanPotRecParticles","rp",rad::constant::M_pro());
       }
       
       void B0Proton(const std::string name="pprime"){
+	//DetectorParticle(name, "ReconstructedTruthSeededChargedParticles","B0",rad::constant::M_pro());
+	
 	Reaction()->setBranchAlias("ReconstructedTruthSeededChargedParticles.momentum.x","B0_px");
 	Reaction()->setBranchAlias("ReconstructedTruthSeededChargedParticles.momentum.y","B0_py");
 	Reaction()->setBranchAlias("ReconstructedTruthSeededChargedParticles.momentum.z","B0_pz");
+	Reaction()->setBranchAlias("ReconstructedTruthSeededChargedParticles.mass","B0_m");
+	Reaction()->setBranchAlias("ReconstructedTruthSeededChargedParticles.PDG","B0_pdg");
 	
-	Reaction()->Define(Rec()+"B0proton",Form("rad::epic::Particle(B0_px,B0_py,B0_pz,0.93827208943,%spx,%spy,%spz,%sm,{0})",Rec().data(),Rec().data(),Rec().data(),Rec().data()));
-	Reaction()->AddParticleName(Rec()+"B0proton");
+	/* Reaction()->Define(Rec()+"B0proton",Form("rad::epic::Particle(B0_px,B0_py,B0_pz,0.93827208943,%spx,%spy,%spz,%sm,{0})",Rec().data(),Rec().data(),Rec().data(),Rec().data())); */
+	/* Reaction()->AddParticleName(Rec()+"B0proton"); */
+	/* Reaction()->Define(Rec()+"B0Proton",Form("if(rec_%s==-1) return rad::epic::Particle(%s,B0_px,B0_py,B0_pz,B0_m,B0_pdg,%spx,%spy,%spz,%sm,%spid,{0})",name.data(),name.data(),Rec().data(),Rec().data(),Rec().data(),Rec().data(),Rec().data())); */
+	/* Reaction()->AddParticleName(Rec()+"B0Proton"); */
+	
       }
       
       void FarForwardProton(const std::string name="pprime"){
 	RomanPotProton(name);
 	B0Proton(name);
+	/* Reaction()->Define(Rec()+"B0proton",Form("rad::epic::Particle(B0_px,B0_py,B0_pz,0.93827208943,%spx,%spy,%spz,%sm,{0})",Rec().data(),Rec().data(),Rec().data(),Rec().data())); */
+	/* Reaction()->AddParticleName(Rec()+"B0proton"); */
       }
       
       void ZDCLambda(const std::string name="lambda"){
@@ -136,7 +135,7 @@ namespace rad{
 	Reaction()->setBranchAlias(branchname+".mass",aliasname+"_m");
 	Reaction()->setBranchAlias(branchname+".PDG",aliasname+"_pdg");
 	
-	Reaction()->Define(Rec()+name,Form("rad::epic::Particle(%s_px,%s_py,%s_pz,%s_m,%spx,%spy,%spz,%sm,,%spdg,{0}",aliasname.data(),aliasname.data(),aliasname.data(),aliasname.data(),Rec().data(),Rec().data(),Rec().data(),Rec().data(),Rec().data()));
+	Reaction()->Define(Rec()+name,Form("rad::epic::Particle(%s_px,%s_py,%s_pz,%s_m,%s_pdg,%spx,%spy,%spz,%sm,%spid,{0})",aliasname.data(),aliasname.data(),aliasname.data(),aliasname.data(),aliasname.data(),Rec().data(),Rec().data(),Rec().data(),Rec().data(),Rec().data()));
 	Reaction()->AddParticleName(Rec()+name);
 	
       }

--- a/include/ePICParticleCreator.h
+++ b/include/ePICParticleCreator.h
@@ -16,26 +16,37 @@ namespace rad{
     /// p4 is the beam particle vector
     /// iafter is to keep the prototype of other particle adding
     /// functions which depend on other particles
-    template<typename Tp, typename Tm>
-      int Particle(const RVec<Tp> &tpx, const  RVec<Tp> &tpy, const  RVec<Tp> &tpz, const RVec<Tm> &tmass, RVec<Tp> &px, RVec<Tp> &py, RVec<Tp> &pz, RVec<Tp> &m,const RVecI& iafter){
+    template<typename Tp, typename Tm, typename Tpdg>
+      int Particle(const RVec<Tp> &tpx, const  RVec<Tp> &tpy, const  RVec<Tp> &tpz, const RVec<Tm> &tmass, const RVec<Tpdg> tpdg, RVec<Tp> &px, RVec<Tp> &py, RVec<Tp> &pz, RVec<Tp> &m, RVec<Tpdg> &pdg, const RVecI& iafter){
       
       //std::cout<<"ParticleFixedBeam "<< px.size()<<m<<m.size()<<std::endl;
       UInt_t entry = 0;
       auto idx = px.size();
       if(tpx.empty()==false){
 	//add new components
-	px.push_back(tpx[entry]);
-	py.push_back(tpy[entry]);
-	pz.push_back(tpz[entry]);
-	m.push_back(tmass[entry]);
-	//m.push_back(0.00051099900);
+	/* px.push_back(tpx[entry]); */
+	/* py.push_back(tpy[entry]); */
+	/* pz.push_back(tpz[entry]); */
+	/* m.push_back(tmass[entry]); */
+	/* pdg.push_back(tpdg[entry]); */
+	px = (tpx[entry]);
+	py = (tpy[entry]);
+	pz = (tpz[entry]);
+	m = (tmass[entry]);
+	pdg = (tpdg[entry]);
+	
       }
       else{
-	px.push_back(0.);
-	py.push_back(0.);
-	pz.push_back(0.);
-	m.push_back(0.);
-	//m.push_back(0.00051099900);
+	/* px.push_back(0.); */
+	/* py.push_back(0.); */
+	/* pz.push_back(0.); */
+	/* m.push_back(0.); */
+	px = (0.);
+	py = (0.);
+	pz = (0.);
+	m = (0.);
+	pdg = (0.);
+	
       }
       return idx;
     }
@@ -107,21 +118,15 @@ namespace rad{
 	Reaction()->AddParticleName(Rec()+"B0proton");
       }
       
-      void ZDCLambda(const std::string name="lambda"){
-	Reaction()->setBranchAlias("ReconstructedFarForwardZDCLambdas.momentum.x","ZDC_px");
-	Reaction()->setBranchAlias("ReconstructedFarForwardZDCLambdas.momentum.y","ZDC_py");
-	Reaction()->setBranchAlias("ReconstructedFarForwardZDCLambdas.momentum.z","ZDC_pz");
-	Reaction()->setBranchAlias("ReconstructedFarForwardZDCLambdas.momentum.x","ZDC_px");
-	Reaction()->setBranchAlias("ReconstructedFarForwardZDCLambdas.momentum.y","ZDC_py");
-	Reaction()->setBranchAlias("ReconstructedFarForwardZDCLambdas.PDG","ZDC_pdg");
-	
-	Reaction()->Define(Rec()+"ZDClambda",Form("rad::epic::Particle(ZDC_px,ZDC_py,ZDC_pz,1.1115683,%spx,%spy,%spz,%sm,{0})",Rec().data(),Rec().data(),Rec().data(),Rec().data()));
-	Reaction()->AddParticleName(Rec()+"ZDClambda");
-
+      void FarForwardProton(const std::string name="pprime"){
+	RomanPotProton(name);
+	B0Proton(name);
       }
       
-      //to do - swap above functions to call this one
-      //and check for bugs
+      void ZDCLambda(const std::string name="lambda"){
+	DetectorParticle(name,"ReconstructedFarForwardZDCLambdas","ZDC",rad::constant::M_Lambda());
+      }
+      
       void DetectorParticle(const std::string name, const std::string branchname, const std::string aliasname, const double mass){
 	std::string smass = to_string(mass);
 	
@@ -129,10 +134,10 @@ namespace rad{
 	Reaction()->setBranchAlias(branchname+".momentum.y",aliasname+"_py");
 	Reaction()->setBranchAlias(branchname+".momentum.z",aliasname+"_pz");
 	Reaction()->setBranchAlias(branchname+".mass",aliasname+"_m");
+	Reaction()->setBranchAlias(branchname+".PDG",aliasname+"_pdg");
 	
-	//Reaction()->Define(Rec()+aliasname,Form("rad::epic::Particle(%s_px,%s_py,%s_pz,%s,%spx,%spy,%spz,%sm,{0}",aliasname.data(),aliasname.data(),aliasname.data(),smass.data(),Rec().data(),Rec().data(),Rec().data(),Rec().data()));
-	Reaction()->Define(Rec()+aliasname,Form("rad::epic::Particle(%s_px,%s_py,%s_pz,%s_m,%spx,%spy,%spz,%sm,{0}",aliasname.data(),aliasname.data(),aliasname.data(),aliasname.data(),Rec().data(),Rec().data(),Rec().data(),Rec().data()));
-	Reaction()->AddParticleName(Rec()+aliasname);
+	Reaction()->Define(Rec()+name,Form("rad::epic::Particle(%s_px,%s_py,%s_pz,%s_m,%spx,%spy,%spz,%sm,,%spdg,{0}",aliasname.data(),aliasname.data(),aliasname.data(),aliasname.data(),Rec().data(),Rec().data(),Rec().data(),Rec().data(),Rec().data()));
+	Reaction()->AddParticleName(Rec()+name);
 	
       }
 

--- a/include/ePICParticleModifier.h
+++ b/include/ePICParticleModifier.h
@@ -18,12 +18,36 @@ namespace rad{
     public:
       
     ePICParticleModifier(rad::config::ConfigReaction& cr): ParticleModifier{cr}{};
- 
-     
-
+      
+      void UndoCrossAngle(const std::string& particle){
+	std::vector<std::string> vars = {particle, Rec()+"px", Rec()+"py", Rec()+"pz", Rec()+"m"};
+	auto func_call_str = rad::utils::createFunctionCallStringFromVec("rad::epic::UndoCrossAnglePart", vars);
+	//_modifications.push_back(func_call_str);
+	addModification(func_call_str);
+	
+      }
 
     };
-
+     
+      template <typename Tp, typename Tm>
+	bool UndoCrossAnglePart(const int idx, RVec<Tp> &px, RVec<Tp> &py, RVec<Tp> &pz, RVec<Tm> &m){
+	    
+	auto cross_angle = 25e-3;
+	    auto vec = PxPyPzMVector(px[idx], py[idx], pz[idx], m[idx]);
+	    RotationY UndoAB(cross_angle);
+	    auto new_vec = UndoAB(vec);
+	    px[idx] = new_vec.X();
+	    py[idx] = new_vec.Y();
+	    pz[idx] = new_vec.Z();
+	    
+	    /* if(!std::isnan(vec.X())){ */
+	    /*   cout << "Before: " << vec << endl; */
+	    /*   cout << "After: " << new_vec << endl; */
+	    /* } */
+	    
+	    return true;
+      }
+    
 
 
 


### PR DESCRIPTION
ePICParticleCreator working for non mc matching functions. Tried a few different things and settled on close to what existed. Roman Pots and B0 create a seperate particle each. Later user can choose what to do with them, i.e. use base rad particle modifier logic to overwrite their pprime, for example.

Also added undocross angle function which can be used for ZDClambdas for now.